### PR TITLE
perf: enable WASM SIMD128 SSE2 backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ option(LW_BUILD_HTTP_DEMO
     "Build the cross-platform cpp-httplib HTTP OCR Demo" ON)
 option(LW_BUILD_CSHARP_DEMOS
     "Build the .NET Framework 3.5 WinForms Demo on Windows" OFF)
+option(LW_WASM_SIMD128
+    "Enable portable WebAssembly SIMD128 for the standalone OCR HTML" ON)
 
 if(LW_BUILD_HTTP_DEMO)
     enable_language(CXX)
@@ -178,6 +180,13 @@ function(lw_configure_runtime_target target)
             -Wall -Wextra -Wpedantic -Werror)
         target_link_libraries(${target} PUBLIC m)
     endif()
+    if(EMSCRIPTEN AND LW_WASM_SIMD128)
+        # Keep the offline single-HTML build single-threaded, but compile its
+        # scalar/SSE2-compatible kernels to portable WebAssembly SIMD128.
+        # -msse2 enables Emscripten's compatible <emmintrin.h> surface;
+        # -msimd128 lowers those intrinsics to portable WASM SIMD instructions.
+        target_compile_options(${target} PRIVATE -O3 -msimd128 -msse2)
+    endif()
 endfunction()
 
 add_library(lw_ppocr_c STATIC ${LW_PPOCR_C_SOURCES})
@@ -205,8 +214,13 @@ if(EMSCRIPTEN)
     target_link_libraries(lw_ppocr_web PRIVATE lw_ppocr_c)
     target_include_directories(lw_ppocr_web PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
     target_compile_features(lw_ppocr_web PRIVATE c_std_11)
-    target_compile_options(lw_ppocr_web PRIVATE -Wall -Wextra -Wpedantic -Werror)
+    target_compile_options(lw_ppocr_web PRIVATE -O3 -Wall -Wextra -Wpedantic -Werror)
+    if(LW_WASM_SIMD128)
+        target_compile_options(lw_ppocr_web PRIVATE -msimd128 -msse2)
+        target_link_options(lw_ppocr_web PRIVATE -msimd128)
+    endif()
     target_link_options(lw_ppocr_web PRIVATE
+        -O3
         "-sMODULARIZE=1" "-sEXPORT_NAME=LwPpocrModule" "-sSINGLE_FILE=1"
         "-sFORCE_FILESYSTEM=1" "-sALLOW_MEMORY_GROWTH=1" "-sNO_EXIT_RUNTIME=1"
         "-sEXPORTED_RUNTIME_METHODS=['FS','HEAPU8','HEAPU32','HEAPF32']"

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -7,7 +7,12 @@ verification.
 |---|---:|---:|---:|---|
 | Windows x64 (VS 2022 baseline) | Yes | Yes | Windows 10 development host | Full OCR, DLL/static package and installed HTTP Demo pass |
 | Linux x86_64 (Ubuntu 22.04 baseline) | Yes | Yes | No | Full OCR, package and installed HTTP Demo pass in CI |
-| Browser WASM (Chromium baseline) | Yes | Yes | No | Standalone HTML runs real OCR repeatedly with stable WASM heap in CI |
+| Browser WASM (modern Chromium / Firefox / Safari) | Yes | Yes | No | Standalone HTML runs real OCR repeatedly with stable WASM heap in CI; SIMD128 is enabled by default |
+
+The offline HTML remains a single-threaded module and can still be opened directly from
+`file://`. Its default `LW_WASM_SIMD128=ON` build requires a browser with WebAssembly
+SIMD support. Configure with `-DLW_WASM_SIMD128=OFF` only when a scalar fallback is
+needed for an older browser.
 | Linux ARM64 | Yes | No | No | Planned primary target |
 | Windows 7 SP1 x64 | Yes | No | No | Planned compatibility validation |
 | Windows 7 SP1 x86 | Yes | No | No | Compatibility profile; not a v0.1 blocker |

--- a/src/simd/cpu_features.c
+++ b/src/simd/cpu_features.c
@@ -7,6 +7,12 @@
 
 #include <stddef.h>
 
+#if defined(__EMSCRIPTEN__) && defined(__wasm_simd128__)
+#  define LW_EMSCRIPTEN_SIMD128 1
+#else
+#  define LW_EMSCRIPTEN_SIMD128 0
+#endif
+
 #if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 #  include <intrin.h>
 #elif defined(__i386__) || defined(__x86_64__)
@@ -14,7 +20,10 @@
 #endif
 
 lw_simd_level lw_detect_simd_level(void) {
-#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+#if LW_EMSCRIPTEN_SIMD128
+    /* The module itself requires SIMD128, so no runtime CPUID probe exists. */
+    return LW_SIMD_LEVEL_SSE2;
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
     int registers[4];
     int maximum_leaf;
     int has_sse2;

--- a/src/simd/simd_platform.h
+++ b/src/simd/simd_platform.h
@@ -1,0 +1,27 @@
+#ifndef LW_SIMD_PLATFORM_H
+#define LW_SIMD_PLATFORM_H
+
+/*
+ * The Emscripten toolchain translates the portable SSE2 intrinsic subset to
+ * WebAssembly SIMD128 when the translation unit is compiled with
+ * -msimd128.  Keeping this small compatibility layer lets the existing SSE2
+ * kernels serve as the first WASM SIMD backend without changing their
+ * numerical algorithms or the public runtime ABI.
+ */
+#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__) || \
+    (defined(__EMSCRIPTEN__) && defined(__wasm_simd128__))
+#  include <emmintrin.h>
+#  define LW_SIMD_HAS_SSE2_INTRINSICS 1
+#else
+#  define LW_SIMD_HAS_SSE2_INTRINSICS 0
+#endif
+
+/* target("sse2") is meaningful only for native x86 Clang/GCC builds. */
+#if LW_SIMD_HAS_SSE2_INTRINSICS && !defined(__EMSCRIPTEN__) && \
+    (defined(__GNUC__) || defined(__clang__))
+#  define LW_SIMD_SSE2_TARGET __attribute__((target("sse2")))
+#else
+#  define LW_SIMD_SSE2_TARGET
+#endif
+
+#endif

--- a/src/simd/sse2_binary.c
+++ b/src/simd/sse2_binary.c
@@ -1,17 +1,11 @@
 #include "simd_kernels.h"
+#include "simd_platform.h"
 
 #include <stddef.h>
 
-#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__)
-#  include <emmintrin.h>
-#  define LW_COMPILES_SSE2_BINARY 1
-#else
-#  define LW_COMPILES_SSE2_BINARY 0
-#endif
+#define LW_COMPILES_SSE2_BINARY LW_SIMD_HAS_SSE2_INTRINSICS
 
-#if LW_COMPILES_SSE2_BINARY && (defined(__GNUC__) || defined(__clang__))
-__attribute__((target("sse2")))
-#endif
+LW_SIMD_SSE2_TARGET
 void lw_sse2_binary_contiguous_f32(
     lw_scalar_binary_op operation,
     const float* left,
@@ -44,9 +38,7 @@ void lw_sse2_binary_contiguous_f32(
                                     output + (size_t)index, element_count - index);
 }
 
-#if LW_COMPILES_SSE2_BINARY && (defined(__GNUC__) || defined(__clang__))
-__attribute__((target("sse2")))
-#endif
+LW_SIMD_SSE2_TARGET
 void lw_sse2_binary_right_scalar_f32(
     lw_scalar_binary_op operation,
     const float* left,

--- a/src/simd/sse2_conv1x1.c
+++ b/src/simd/sse2_conv1x1.c
@@ -1,19 +1,13 @@
 #include "simd_kernels.h"
+#include "simd_platform.h"
 
 #include "scalar_kernels.h"
 
 #include <stddef.h>
 
-#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__)
-#  include <emmintrin.h>
-#  define LW_COMPILES_SSE2_CONV1X1 1
-#else
-#  define LW_COMPILES_SSE2_CONV1X1 0
-#endif
+#define LW_COMPILES_SSE2_CONV1X1 LW_SIMD_HAS_SSE2_INTRINSICS
 
-#if LW_COMPILES_SSE2_CONV1X1 && (defined(__GNUC__) || defined(__clang__))
-__attribute__((target("sse2")))
-#endif
+LW_SIMD_SSE2_TARGET
 void lw_sse2_conv1x1_unit_f32(
     const float* input,
     const float* weights,

--- a/src/simd/sse2_conv2x2.c
+++ b/src/simd/sse2_conv2x2.c
@@ -1,19 +1,13 @@
 #include "simd_kernels.h"
+#include "simd_platform.h"
 
 #include "scalar_kernels.h"
 
 #include <stddef.h>
 
-#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__)
-#  include <emmintrin.h>
-#  define LW_COMPILES_SSE2_CONV2X2 1
-#else
-#  define LW_COMPILES_SSE2_CONV2X2 0
-#endif
+#define LW_COMPILES_SSE2_CONV2X2 LW_SIMD_HAS_SSE2_INTRINSICS
 
-#if LW_COMPILES_SSE2_CONV2X2 && (defined(__GNUC__) || defined(__clang__))
-__attribute__((target("sse2")))
-#endif
+LW_SIMD_SSE2_TARGET
 void lw_sse2_conv2x2_unit_pad_end1_f32(const float* input, const float* weights, const float* bias,
                                        float* output, const int32_t input_dimensions[4],
                                        const int32_t output_dimensions[4]) {

--- a/src/simd/sse2_conv3x3.c
+++ b/src/simd/sse2_conv3x3.c
@@ -1,19 +1,13 @@
 #include "simd_kernels.h"
+#include "simd_platform.h"
 
 #include "scalar_kernels.h"
 
 #include <stddef.h>
 
-#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__)
-#  include <emmintrin.h>
-#  define LW_COMPILES_SSE2_CONV3X3 1
-#else
-#  define LW_COMPILES_SSE2_CONV3X3 0
-#endif
+#define LW_COMPILES_SSE2_CONV3X3 LW_SIMD_HAS_SSE2_INTRINSICS
 
-#if LW_COMPILES_SSE2_CONV3X3 && (defined(__GNUC__) || defined(__clang__))
-__attribute__((target("sse2")))
-#endif
+LW_SIMD_SSE2_TARGET
 void lw_sse2_conv3x3_unit_pad1_f32(const float* input, const float* weights, const float* bias,
                                    float* output, const int32_t input_dimensions[4],
                                    const int32_t output_dimensions[4]) {

--- a/src/simd/sse2_depthwise3x3.c
+++ b/src/simd/sse2_depthwise3x3.c
@@ -1,17 +1,11 @@
 #include "simd_kernels.h"
+#include "simd_platform.h"
 
 #include <stddef.h>
 
-#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__)
-#  include <emmintrin.h>
-#  define LW_COMPILES_SSE2_DEPTHWISE3X3 1
-#else
-#  define LW_COMPILES_SSE2_DEPTHWISE3X3 0
-#endif
+#define LW_COMPILES_SSE2_DEPTHWISE3X3 LW_SIMD_HAS_SSE2_INTRINSICS
 
-#if LW_COMPILES_SSE2_DEPTHWISE3X3 && (defined(__GNUC__) || defined(__clang__))
-__attribute__((target("sse2")))
-#endif
+LW_SIMD_SSE2_TARGET
 void lw_sse2_depthwise_conv3x3_unit_pad1_f32(
     const float* input,
     const float* weights,

--- a/src/simd/sse2_depthwise5x5.c
+++ b/src/simd/sse2_depthwise5x5.c
@@ -1,19 +1,13 @@
 #include "simd_kernels.h"
+#include "simd_platform.h"
 
 #include "scalar_kernels.h"
 
 #include <stddef.h>
 
-#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__)
-#  include <emmintrin.h>
-#  define LW_COMPILES_SSE2_DEPTHWISE5X5 1
-#else
-#  define LW_COMPILES_SSE2_DEPTHWISE5X5 0
-#endif
+#define LW_COMPILES_SSE2_DEPTHWISE5X5 LW_SIMD_HAS_SSE2_INTRINSICS
 
-#if LW_COMPILES_SSE2_DEPTHWISE5X5 && (defined(__GNUC__) || defined(__clang__))
-__attribute__((target("sse2")))
-#endif
+LW_SIMD_SSE2_TARGET
 void lw_sse2_depthwise_conv5x5_unit_pad2_f32(const float* input, const float* weights,
                                              const float* bias, float* output,
                                              const int32_t dimensions[4]) {

--- a/src/simd/sse2_matmul.c
+++ b/src/simd/sse2_matmul.c
@@ -1,17 +1,11 @@
 #include "simd_kernels.h"
+#include "simd_platform.h"
 
 #include <stddef.h>
 
-#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__)
-#  include <emmintrin.h>
-#  define LW_COMPILES_SSE2 1
-#else
-#  define LW_COMPILES_SSE2 0
-#endif
+#define LW_COMPILES_SSE2 LW_SIMD_HAS_SSE2_INTRINSICS
 
-#if LW_COMPILES_SSE2 && (defined(__GNUC__) || defined(__clang__))
-__attribute__((target("sse2")))
-#endif
+LW_SIMD_SSE2_TARGET
 void lw_sse2_matmul_shared_f32(
     const float* input,
     const float* weights,

--- a/src/simd/sse2_packed_conv1x1.c
+++ b/src/simd/sse2_packed_conv1x1.c
@@ -1,19 +1,13 @@
 #include "simd_kernels.h"
+#include "simd_platform.h"
 
 #include "packed_conv_internal.h"
 
 #include <stddef.h>
 
-#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__)
-#  include <emmintrin.h>
-#  define LW_COMPILES_SSE2_PACKED_CONV1X1 1
-#else
-#  define LW_COMPILES_SSE2_PACKED_CONV1X1 0
-#endif
+#define LW_COMPILES_SSE2_PACKED_CONV1X1 LW_SIMD_HAS_SSE2_INTRINSICS
 
-#if LW_COMPILES_SSE2_PACKED_CONV1X1 && (defined(__GNUC__) || defined(__clang__))
-__attribute__((target("sse2")))
-#endif
+LW_SIMD_SSE2_TARGET
 void lw_sse2_packed_conv1x1_f32(const float* input, const float* packed_weights,
                                 const float* bias, float* output,
                                 const int32_t input_dimensions[4],


### PR DESCRIPTION
启用 WASM SIMD128，并复用现有 SSE2 内核；保持单 HTML、单线程运行，支持通过 LW_WASM_SIMD128=OFF 回退标量版本。